### PR TITLE
Updated environment.yml with more packages

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,3 +34,7 @@ dependencies:
     - pyflakes 
     - autopep8 
     - yapf
+    - anaconda-client
+    - anaconda-navigator
+    - conda-build
+    - cartopy

--- a/environment.yml
+++ b/environment.yml
@@ -1,12 +1,36 @@
 name: geog0111
 channels:
-  - conda-forge
+    - anaconda
+    - conda-forge
 dependencies:
-  - python>=3.7
-  - ipython
-  - jupyter
-  - numpy
-  - matplotlib
-  - pandas
-  - gdal>=2.3
-
+    - python>=3.6
+    - ipython
+    - numpy 
+    - scipy
+    - matplotlib 
+    - gdal>2.2
+    - pandas  
+    - fiona
+    - rasterio 
+    - jupyter_contrib_nbextensions 
+    - jupyter_latex_envs 
+    - jupyter_nbextensions_configurator 
+    - jupyterlab 
+    - jupyterlab_launcher
+    - ipyleaflet 
+    - scikit-learn 
+    - scikit-image 
+    - geopandas 
+    - sphinx 
+    - pandoc 
+    - seaborn 
+    - shapely 
+    - spyder 
+    - statsmodels 
+    - xarray 
+    - pyephem 
+    - requests 
+    - pep8 
+    - pyflakes 
+    - autopep8 
+    - yapf


### PR DESCRIPTION
I have updated the `environment.yml` file with more relevant packages that we use/used to use in the course and/or that are useful for students to have around. I have tested this from a clean Miniconda and Anaconda installs, and also on mybinder.org. Only issue to what's already installed is that it will downgrade python from 3.7 to 3.6, but that's not that relevant. One way to install this after anaconda or miniconda is to 

    conda update --yes --all
    conda env update -n base -f environment.yml

(the first line is not necessary, really). This upgrades the root or default environment. If you wanted to install on its own environment, just change `base` to whatever you want to call the environment.

